### PR TITLE
Update GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/check-badges.yml
+++ b/.github/workflows/check-badges.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check badges in README.md
         run: ./scripts/check-badges.bash "README.md"

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -11,8 +11,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: "corretto"
           java-version: 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,9 @@ jobs:
         java-version: [11, 21]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java-version }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           # Use same in Dockerfile
           distribution: "corretto"
@@ -40,15 +40,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 17
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
 
       - name: Build Java library JAR
         run: mvn package -Dmaven.test.skip=true
@@ -63,7 +63,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Cache AVD
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.android/avd/*


### PR DESCRIPTION
## Summary
- GitHub is deprecating Node 20 on Actions runners (EOL April 2026, removal Fall 2026)
- Updated all actions to their latest major versions with Node 24 runtime support
- actions/checkout v4 → v6
- actions/setup-java v3/v4 → v5
- gradle/actions/setup-gradle v4 → v5
- actions/cache v4 → v5

## Test plan
- [ ] CI workflows pass on this PR branch
- [ ] Checkstyle workflow passes