### PR TITLE
Trim trailing empty line from README.md

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,10 @@ update:
 insert-example:
 	./scripts/insert-example.bash
 
+.PHONY: format-doc
+format-doc:
+	# Trim trailing empty line
+	sed -i -e '$${/^$$/d;}' README.md
+
 .PHONY: after-gen
-after-gen: fix format insert-example
+after-gen: fix format insert-example format-doc


### PR DESCRIPTION
## Summary
- Add `format-doc` target to trim trailing empty line from README.md after generation

## Test plan
- [ ] Verify `make after-gen` runs successfully
- [ ] Verify README.md has no trailing empty line after generation