### PR TITLE
Fix insert-example adding extra trailing newline

### DIFF
--- a/scripts/insert-example.py
+++ b/scripts/insert-example.py
@@ -20,7 +20,7 @@ def main(template: typing.TextIO) -> None:
         return read_text(file_name)
 
     text = REPLACE_RE.sub(sub_match, content)
-    print(text)
+    print(text, end="")
 
 
 def parse_args() -> typing.Dict[str, typing.Any]:


### PR DESCRIPTION
## Summary
- Fix `insert-example.py` using `print(text, end="")` to avoid adding extra trailing newline

## Test plan
- [ ] Run `make after-gen` and verify README.md has no trailing empty line